### PR TITLE
Fix compilation

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -20,6 +20,8 @@ opt=opts.Add('DEBUG','debug level',0)
 env=Environment(options=opts, ENV=os.environ)
 debug=1 #int(env['DEBUG'])
 
+env.Append(CCFLAGS='-Wall')
+
 if (debug>0):
   env.Append(CCFLAGS='-g')
   env.Append(CPPDEFINES=["DEBUG"])
@@ -36,7 +38,7 @@ env.Append(CPPDEFINES=["_FILE_OFFSET_BITS=64", "_LARGEFILE_SOURCE", "_REENTRANT"
 for v in ("CXX","LINK"):
   if (v in os.environ):
     env.Replace(**{v: os.environ[v]})
-    
+
 ###### CONTEXT CHECKS
 
 conf=Configure(env)
@@ -54,11 +56,11 @@ if (not env.GetOption('clean')):
     print "Checking for libfuse... not found"
     sys.stderr.write("fatal: libfuse not found\n")
     sys.exit(1)
-  
+
   conf.env.Append(LIBS=['stdc++'])
-  
+
 ### FINISH
-    
+
 env=conf.Finish()
 
 ###### WORK

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,13 @@
 
 /*  tffs - Top Field File System driver for FUSE
     Copyright (c) 2005 Sven Over <svenover@svenover.de>
-    
+
     All information on the T*PFIELD file system, and also some
     parts of the code (especially the data structures in topfield.h),
     are taken from the original
     "Console driver program for Topfield TF4000PVR disk processing"
     Copyright (c) 2002 Petr Novak <topfield@centrum.cz>
-    
+
     Some parts of the code are taken from example programs included in
     "FUSE: Filesystem in Userspace"
     Copyright (c) 2001-2005  Miklos Szeredi <miklos@szeredi.hu>
@@ -74,7 +74,7 @@ tffs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 
   if (err != 0)
     return err;
-    
+
   err = tf->readdir(inode, &first, &count);
   if (err != 0)
     return err;
@@ -102,7 +102,7 @@ tffs_open(const char *path, struct fuse_file_info *fi)
   int err;
   fprintf(stderr, "tffs_open(%s)\n", path);
   inode = tf->inode4path(path, &err);
-  
+
   if (err)
     return err;
 
@@ -128,10 +128,9 @@ static int tffs_read(const char *path, char *buf, size_t size, off_t offset,
 static int
 tffs_statfs(const char *path, struct statfs *sfs)
 {
-  tfinode_ptr inode;
   int err = 0;
   fprintf(stderr, "tffs_statfs(%s)\n", path);
-  inode = tf->inode4path(path, &err);
+  (void)tf->inode4path(path, &err);
   if (!err) {
     // sfs->f_type = ('t'<<24)|('f'<<16)|('f'<<8)|('s');
     sfs->f_bsize = tf->getclustersize();
@@ -192,15 +191,19 @@ int main(int argc, char *argv[])
 
   // Create tfdisk object
   tfdisk tfd(device);
-
   tf = &tfd;
 
   if (tfd.open()) {
-    //fprintf(stderr,"%s: %s\n",argv[0],strerror(errno));
+    fprintf(stderr,"%s: %s\n",argv[0],strerror(errno));
     exit(1);
   }
-  
+
   // Run FUSE main loop
   newargv[newargc] = NULL;
-  return fuse_main(newargc, newargv, &tffs_oper);
+  int fuseRet = fuse_main(newargc, newargv, &tffs_oper);
+  if (fuseRet) {
+    fprintf(stderr,"Fuse_main return error: %d:", fuseRet);
+  }
+
+  return fuseRet;
 }

--- a/src/tfdisk.cpp
+++ b/src/tfdisk.cpp
@@ -1,12 +1,12 @@
 /*  tffs - Top Field File System driver for FUSE
     Copyright (c) 2005 Sven Over <svenover@svenover.de>
-    
+
     All information on the T*PFIELD file system, and also some
     parts of the code (especially the data structures in topfield.h),
     are taken from the original
     "Console driver program for Topfield TF4000PVR disk processing"
     Copyright (c) 2002 Petr Novak <topfield@centrum.cz>
-    
+
     Some parts of the code are taken from example programs included in
     "FUSE: Filesystem in Userspace"
     Copyright (c) 2001-2005  Miklos Szeredi <miklos@szeredi.hu>
@@ -26,7 +26,7 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-// #include <cunistd>
+#include <unistd.h>
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -199,7 +199,6 @@ int
 tfdisk::open()
 {
   int err = 0;
-  const std::vector<tfinode_ptr> *root;
 
   if (_fd >= 0)
     close();
@@ -238,7 +237,7 @@ tfdisk::open()
   }
   // is the device a T*PFIELD PVR HDD?
   _type = TF_UNKNOWN;
-  
+
   if (strcmp(superblock.signature, "TOPFIELD PVR HDD") == 0) {
     _type = TF_4000;
     DEBUGMSG("Found TF4000, version %04x", superblock.version);
@@ -253,20 +252,20 @@ tfdisk::open()
     return errno;
   }
 
-  DEBUGMSG("Size %lld/%lldK/%lldM", _size, _size/1024LL, _size/1024LL/1024LL);
+  DEBUGMSG("Size %ld/%lldK/%lldM", _size, _size/1024LL, _size/1024LL/1024LL);
   _lba_sectors = _size / 512LL;
-  DEBUGMSG("Sectors %lld/0x%08llx", _lba_sectors, _lba_sectors);
+  DEBUGMSG("Sectors %ld/0x%08lx", _lba_sectors, _lba_sectors);
   _cluster_size = swap16(superblock.cluster_size) << 9;
-  DEBUGMSG("Clustersize %04ld sectors / 0x%04lx bytes", swap16(superblock.cluster_size), _cluster_size);
+  DEBUGMSG("Clustersize %04d sectors / 0x%04x bytes", swap16(superblock.cluster_size), _cluster_size);
 
   delete [] _buffer;
   _buffer = NULL;
   _buffer = new uint8_t [_cluster_size];
 
   _fatitems = ((uint32_t) (_lba_sectors / (_cluster_size >> 9))) - 1;
-  DEBUGMSG("%ld clusters", _fatitems);
+  DEBUGMSG("%d clusters", _fatitems);
   if (_fatitems > TF_MAXFATSIZE) {
-    DEBUGMSG("TF_MAXFATSIZE %ld", TF_MAXFATSIZE);
+    DEBUGMSG("TF_MAXFATSIZE %d", TF_MAXFATSIZE);
     _fatitems = TF_MAXFATSIZE;
   }
   // read FAT table
@@ -333,7 +332,7 @@ tfdisk::inodeptr(uint32_t n)
 tfinode_ptr
 tfdisk::inode4path(const char *path, int *err)
 {
-  tfinode_ptr inode;
+  tfinode_ptr inode = 0;
 
   *err = 0;
   DEBUGMSG("inode4path(%s)", path);
@@ -369,13 +368,13 @@ tfdisk::inode4path(const char *path, int *err)
   // split path at '/'
   // read directory
   // compare entries with path elements
-  // 
+  //
   for(;;) {
     const char *next = strchr(++path, '/');
     if (!next)
       next = path + strlen(path);
-    DEBUGMSG("Looking for <%s>[%d]", path, next - path);
-    
+    DEBUGMSG("Looking for <%s>[%ld]", path, next - path);
+
     DEBUGMSG("In loop, reading dir for '%s'", inode->entry.name);
     *err = readdir(inode, &first, &count);
     if (*err)
@@ -404,14 +403,13 @@ tfdisk::inode4path(const char *path, int *err)
 // *************************************************************************
 // tfdisk::readdir
 // collect inodes from cache
-// 
+//
 int
 tfdisk::readdir(tfinode_ptr inode, inode_t *first, int *count )
 {
   int err;
-  uint32_t i;
 
-  DEBUGMSG("tfdisk::readdir(%d)", inode->st.st_ino);
+  DEBUGMSG("tfdisk::readdir(%lu)", inode->st.st_ino);
   err = gen_inodes(inode);
   if (err)
     return err;
@@ -450,28 +448,28 @@ tfdisk::read(inode_t ino, char *buf, size_t size, off_t offset)
   ssize_t written = 0;
 
   while (size > 0 && seq->size > 0) {
-    
+
     DEBUGMSG("size=%lld, seq->size=%lld", (long long) size, (long long) seq->size);
-    
+
     if (offset >= seq->offset + seq->size) {
       ++seq;
       DEBUGMSG("offset(%lld) >= seq->offset(%lld) + seq->size(%lld)", (long long) offset,
                (long long) seq->offset, (long long) seq->size);
     }
-    
+
     // seek to position
     // if offset is an odd number, decrement seek position
     if (seq->size <= (offset - seq->offset))
       continue;
 
-    off_t s64 = (int64_t(seq->size) - (offset - seq->offset));
-    size_t s = (s64 > size) ? size : s64;
+    const off_t s64 = (int64_t(seq->size) - (offset - seq->offset));
+    size_t s = (s64 > (long long int)size) ? size : s64;
 
     if (lseek(_fd, (seq->pos + (offset & ~1ll) - seq->offset), SEEK_SET) == -1) {
       cerr << "lseek: " << strerror(errno) << endl;
       return -EIO;
     }
-    
+
     // if offset is an odd number, read one byte into minibuffer and discard one byte
     // (byte swapping!)
     if ((offset & 1) || (s == 1)) {
@@ -486,7 +484,7 @@ tfdisk::read(inode_t ino, char *buf, size_t size, off_t offset)
         if (rd != 0)
           break;
       }
-      
+
       DEBUGMSG("---");
 
       *buf = minibuffer[(offset & 1) ? 0 : 1];
@@ -525,7 +523,7 @@ tfdisk::read(inode_t ino, char *buf, size_t size, off_t offset)
       for (p = (uint32_t *) buf, e = p + s / 4; p != e; ++p)
 	*p = bswap_32(*p);
     }
-    
+
     written += rd;
     buf += s;
     offset += s;
@@ -547,7 +545,7 @@ tfdisk::read_cluster(cluster_t n)
 {
   off_t pos = ((off_t)(n + 1)) * _cluster_size;
   DEBUGMSG("Read cluster %d at %08lx[sector %08lx]", n, pos, pos>>9);
-  
+
   if (pos + _cluster_size > _size) {
     cerr << "Attempt to read " << _cluster_size << " bytes at " << pos << " which is after end of disk " << _size << " !" << endl;
     return -EFBIG;
@@ -587,8 +585,7 @@ tfdisk::gen_inodes(tfinode_ptr dir)
 {
   int err;
   tf_entry_t *entry = (tf_entry_t *) _buffer;
-  uint32_t tsdb = ~uint32_t(0);
-  
+
   assert(sizeof(tf_entry_t) == 0x80);
 
   DEBUGMSG("gen_inodes for %p", dir);
@@ -597,32 +594,32 @@ tfdisk::gen_inodes(tfinode_ptr dir)
     return -EINVAL;
   if (!S_ISDIR(dir->st.st_mode))
     return -ENOTDIR;
-  
+
   if (dir->count >= 0) { // already cached
     DEBUGMSG("Already cached with %d entries", dir->count);
     return 0;
   }
 
   cluster_t cluster = dir->entry.start_cluster;
-  DEBUGMSG("Not cached, reading cluster %d", cluster);  
+  DEBUGMSG("Not cached, reading cluster %d", cluster);
   // FIXME: handle directories spanning multiple clusters!
   err = read_cluster(cluster);
   if (err)
     return err;
   if (entry->type != 0xF1) {
-    DEBUGMSG("Wrong directory type (%02x != F1) at cluster %ld", entry->type, cluster);
+    DEBUGMSG("Wrong directory type (%02x != F1) at cluster %u", entry->type, cluster);
     return -EINVAL;
   }
 
   // first unused entry in dir, incl. deleted items
   int first_unused = (_cluster_size - swap32(entry->empty_in_last_cluster)) / sizeof(tf_entry_t);
   inode_t ino = _inodes.size();
-  DEBUGMSG("read_dir cluster %ld: %d entries, first inode %d", cluster, first_unused, ino);
+  DEBUGMSG("read_dir cluster %u: %d entries, first inode %d", cluster, first_unused, ino);
   dir->first = ino;
   dir->count = 0; // count valid entries
-  
+
   // traverse directory, generate inodes
-  
+
   for (int dir_entry = 0; dir_entry < first_unused; ++entry, ++dir_entry) {
     mode_t mode;
 //    hexdump((unsigned char *)entry, sizeof(tf_entry_t), stderr, "Entry");
@@ -639,7 +636,7 @@ tfdisk::gen_inodes(tfinode_ptr dir)
       case 0xf1: mode = 0; break; /* '.' -> see filler() in main() */
       case 0xf2: mode = S_IFDIR | 0555; break; /* dr_xr_xr_x dir */
       case 0xf3: mode = S_IFDIR | 0500; break; /* dr_x______ hidden dir */
-      case 0xff: mode = 0; break; /* deleted */ 
+      case 0xff: mode = 0; break; /* deleted */
       default: mode = 0;
 	DEBUGMSG( "Unknown type %02x\n", entry->type);
         break;
@@ -660,7 +657,7 @@ tfdisk::gen_inodes(tfinode_ptr dir)
     inode->entry.type = entry->type;
     (void)conv_name(entry->name, inode->entry.name, sizeof(inode->entry.name)-1);
     DEBUGMSG("\t[%s]'%s' -> '%s' ", entry->channel, entry->name, inode->entry.name);
-    inode->entry.start_cluster = swap32(entry->start_cluster); 
+    inode->entry.start_cluster = swap32(entry->start_cluster);
     inode->entry.count_of_clusters = swap32(entry->count_of_clusters);
     inode->entry.empty_in_last_cluster = swap32(entry->empty_in_last_cluster);
     memcpy(inode->entry.data, entry->data, sizeof(entry->data));
@@ -676,7 +673,7 @@ tfdisk::gen_inodes(tfinode_ptr dir)
     sp->st_blocks = ( uint64_t(inode->entry.count_of_clusters) * _cluster_size + 511 ) / 512;
     sp->st_atime = sp->st_mtime = sp->st_ctime = convert_date_time(inode->entry.data);
     DEBUGMSG("\tstart_cluster %d, count %d, empty %d: %ld MB", inode->entry.start_cluster, inode->entry.count_of_clusters, inode->entry.empty_in_last_cluster, sp->st_size/1024L);
-    
+
     if (sp->st_mode) // only for known types
       gen_filesegments(inode);
 
@@ -697,7 +694,7 @@ tfdisk::read_fat()
   bool fat2bad = false;
 
   DEBUGMSG("read_fat");
-  
+
   _fatalloc = 0;
 
   // Read in the cluster with both FATs
@@ -720,7 +717,7 @@ tfdisk::read_fat()
     }
     // Check each item for validity
     if (val < 0xfffffb && val > (_lba_sectors >> 11)) {
-      DEBUGMSG( "FAT1 item #%d wrong (%ld/%08x)\n", i, val, val);
+      DEBUGMSG( "FAT1 item #%d wrong (%u/%08x)\n", i, val, val);
       if ((val & 0xffff) == i + 1) {
         val &= 0xffff;
       } else {
@@ -746,11 +743,11 @@ tfdisk::read_fat()
 
     if (val < 0xfffffb && val > (_lba_sectors >> 11)) {
 //      cerr << "FAT2 item #" << i << " wrong (" << val << ")!" << endl;
-      DEBUGMSG( "FAT2 item #%d wrong (%ld/%08x)\n", i, val, val);
+      DEBUGMSG( "FAT2 item #%d wrong (%u/%08x)\n", i, val, val);
       val = ~0L;
       fat2bad = true;
     }
-    
+
     fat2.push_back(val);
 
     // Check if FAT1 and FAT2 are identical
@@ -761,7 +758,7 @@ tfdisk::read_fat()
   }
 
   // Copy a valid fat into global variable for later use
-  if (!fat1bad) 
+  if (!fat1bad)
     _fat.swap(fat1);
   else if (!fat2bad)
     _fat.swap(fat2);
@@ -795,7 +792,7 @@ tfdisk::gen_filesegments(tfinode_ptr inode)
   uint32_t clusters = uint32_t(_size / (off_t) _cluster_size);
 
 //  DEBUGMSG("%d segments, start %d, count %d", inode->seg.size(), cluster, clusters);
-  
+
   for (j = 0; j < inode->entry.count_of_clusters && cluster < clusters; ++j) {
     inode->seg[j] =
         tffilesegment((off_t) j * (off_t) _cluster_size, _cluster_size,
@@ -813,8 +810,8 @@ tfdisk::gen_filesegments(tfinode_ptr inode)
   }
   // merge adjacent clusters (will reduce number of file operations)
 
-  int maxclusters = (2u << 30) / _cluster_size - 1;
-  
+  unsigned maxclusters = (2u << 30) / _cluster_size - 1;
+
 //  DEBUGMSG("maxclusters %d", maxclusters);
   for (j = 0; j < inode->entry.count_of_clusters - 1; ++j) {
     uint32_t n = 0;

--- a/src/tfdisk.h
+++ b/src/tfdisk.h
@@ -1,12 +1,12 @@
 /*  tffs - Top Field File System driver for FUSE
     Copyright (c) 2005 Sven Over <svenover@svenover.de>
-    
+
     All information on the T*PFIELD file system, and also some
     parts of the code (especially the data structures in topfield.h),
     are taken from the original
     "Console driver program for Topfield TF4000PVR disk processing"
     Copyright (c) 2002 Petr Novak <topfield@centrum.cz>
-    
+
     Some parts of the code are taken from example programs included in
     "FUSE: Filesystem in Userspace"
     Copyright (c) 2001-2005  Miklos Szeredi <miklos@szeredi.hu>
@@ -61,7 +61,7 @@ struct tfinode
   inode_t first; // first dir entry, if dir, 0 else
   int32_t count; // # of dir entries, if dir, -1 else
 };
-  
+
 typedef enum {
   TF_UNKNOWN = 0,
     TF_4000 = 1,
@@ -91,25 +91,25 @@ class tfdisk
     /// FAT
     typedef std::vector<uint32_t> fat_t;
     fat_t _fat;
-   
+
     // all inodes, indexed by inode #, starting from 1
     std::vector<tfinode_ptr> _inodes;
 
     // read_* functions to real I/O
 
     // read fat table
-    int read_fat();  
+    int read_fat();
 
     // read cluster to buffer
     int read_cluster(cluster_t n);
-   
+
     // collect inodes with same parent
-    // inodes within a directory are consecutive, 
+    // inodes within a directory are consecutive,
     int collect_inodes(tfinode_ptr parent, inode_t *first, int *count);
-   
+
     // generate inodes from directory, return error
     int gen_inodes(tfinode_ptr inode);
-   
+
     // generate file segment data, return error
     int gen_filesegments(tfinode_ptr inode);
 
@@ -117,9 +117,9 @@ class tfdisk
    char *conv_name(const char *inbuf, char *outbuf, size_t size);
 
   public:
-    tfdisk(const char *device) : _devfn(device), _fd(-1), _size(-1), _buffer(NULL), _fat(NULL) {}
+    tfdisk(const char *device) : _devfn(device), _fd(-1), _size(-1), _buffer(NULL), _fat() {}
     ~tfdisk();
-    
+
     int open(); // returning errno
     void close();
 
@@ -131,13 +131,13 @@ class tfdisk
     tfinode_ptr inode4path(const char *path, int *err);
     // get inode by index
     tfinode_ptr inodeptr(uint32_t n);
-   
+
     // read directory (inode pointing to it), return errno
-    // pass index to first new inoded and count back 
+    // pass index to first new inoded and count back
     int readdir(tfinode_ptr inode, inode_t *first, int *count);
     ssize_t read(inode_t ino, char *buf, size_t size, off_t offset);
 
-    uint32_t fsid1() 
+    uint32_t fsid1()
      {
      uint32_t t=0;
      for (fat_t::const_iterator it=_fat.begin(),stop=_fat.end();it!=stop;++it)
@@ -148,7 +148,7 @@ class tfdisk
      {
      return _fatitems^_cluster_size^_lba_sectors^_size^_fd;
      }
-     
+
 };
 
 #endif // __TFDISK_H__


### PR DESCRIPTION
Compiles with gcc (Ubuntu 4.8.4-2ubuntu1~14.04.3) 4.8.4
Enabled and clean all warnings.

Include needed to be added for newer GCC to work. Fixed all compiler warnings for 64bit build. This means that 32bit build will give now warnings for printf format. These could be fixed with this approach http://stackoverflow.com/questions/16949445/ld-format-conversion-for-portability?lq=1
